### PR TITLE
Fixed TextFilter lookup for TextFilters with custom filter_names

### DIFF
--- a/app/helpers/admin/references_helper.rb
+++ b/app/helpers/admin/references_helper.rb
@@ -34,8 +34,7 @@ module Admin::ReferencesHelper
   
   def filter
     @filter ||= begin
-      filter_name = params[:filter_name]
-      (filter_name.gsub(" ", "") + "Filter").constantize unless filter_name.blank?
+      TextFilter.find_descendant(params[:filter_name])
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -158,7 +158,7 @@ module ApplicationHelper
   end
   
   def filter_options_for_select(selected=nil)
-    options_for_select([[t('select.none'), '']] + TextFilter.descendants.map { |s| s.filter_name }.sort, selected)
+    options_for_select([[t('select.none'), '']] + TextFilter.descendants_names, selected)
   end
   
   def body_classes

--- a/app/models/text_filter.rb
+++ b/app/models/text_filter.rb
@@ -21,5 +21,16 @@ class TextFilter
       text = File.read(filename) rescue ""
       self.description text
     end
+
+    def descendant_names
+      descendants.map { |s| s.filter_name }.sort
+    end
+
+    def find_descendant(filter_name)
+      descendants.each do |s|
+        return s if s.filter_name == filter_name
+      end
+      nil
+    end
   end
 end

--- a/spec/helpers/admin/references_helper_spec.rb
+++ b/spec/helpers/admin/references_helper_spec.rb
@@ -1,6 +1,10 @@
 require File.dirname(__FILE__) + '/../../spec_helper'
 
 describe Admin::ReferencesHelper do
+  class CustomFilter < TextFilter
+    filter_name "Really Custom"
+  end
+
   describe "determining the page class" do
     before :each do
       helper.send(:instance_variable_set, :@page_class, nil)
@@ -33,6 +37,11 @@ describe Admin::ReferencesHelper do
     it "should return the filter object for the named filter" do
       params[:filter_name] = "Textile"
       helper.filter.should == TextileFilter
+    end
+
+    it "should return the filter object for a custom named filter" do
+      params[:filter_name] = "Really Custom"
+      helper.filter.should == CustomFilter
     end
 
     it "should return nil when the set filter is blank" do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -179,7 +179,12 @@ describe ApplicationHelper do
   it "should provide the admin object" do
     helper.admin.should == Radiant::AdminUI.instance
   end
-  
+
+  it "should return filter options for select" do
+    helper.filter_options_for_select.should =~ %r{<option value=\"\">&lt;none&gt;</option>}
+    helper.filter_options_for_select.should =~ %r{<option value=\"Markdown\">Markdown</option>}
+  end 
+
   it "should include the regions helper" do
     ApplicationHelper.included_modules.should include(Admin::RegionsHelper)
   end

--- a/spec/models/text_filter_spec.rb
+++ b/spec/models/text_filter_spec.rb
@@ -21,6 +21,10 @@ describe TextFilter do
     CustomFilter.description.should == File.read(File.dirname(__FILE__) + "/../fixtures/sample.txt")
   end
 
+  it 'should descendant_names' do
+    TextFilter.descendant_names.should include("Markdown", "Really Custom", "Reverse", "SmartyPants", "Textile")
+  end
+
   it 'should filter text with base filter' do
     filter = TextFilter.new
     filter.filter('test').should == 'test'


### PR DESCRIPTION
## Problem

For TextFilters with custom filter_names retrieving the filter reference results in an error:
`uninitialized constant CustomFilterNameFilter`
## Reason

The helper method filter_options_for_select returns options where both the value and label are filter_name:

<pre>&lt;option value="Custom Filter Name"&gt;Custom Filter Name&lt;/option&gt;</pre>

The custom name is also what is stored in the database.

When retrieving the html reference, the custom filter_name from is appended with "Filter".
This will result in an error because that's not the name of the class.
## Patch

This patch looks up the TextFilter class by looping through the descendant classes and matching the filter_name.
I've moved the code for generating the options and doing the lookup to the same class.
