### PR TITLE
Index tags

### DIFF
--- a/app/models/standard_tags.rb
+++ b/app/models/standard_tags.rb
@@ -515,11 +515,10 @@ module StandardTags
     
     *Usage:* _The following would render '0012'
     
-    <pre><code><r:index array="items" /><r:index array="widgets" /><r:index array="items" /><r:index array="items" /></code></pre>
+    <pre><code><r:index [array="widgets"] /><r:index array="snippets" /><r:index [array="widgets"] /><r:index [array="widgets"] /></code></pre>
   }
   tag 'index' do |tag|
-    raise TagError, "`index' tag must contain an `array' attribute." unless tag.attr['array']
-    key = tag.attr['array']
+    key = tag.attr['array'] ||= 'array'
 
     if tag.globals.indexes.present?     # If the global indexes array exists
       if tag.globals.indexes[key].nil?  # Set the value of that index to zero if not present
@@ -533,6 +532,19 @@ module StandardTags
     tag.globals.indexes[key] += 1       # Increment the index value on the global object
     
     index                               # Return the stored index
+  end
+  
+  desc %{
+    Resets the counter on an array
+    
+    *Usage:* _The following with render '010'
+    
+    <pre><code><r:index [array="widgets"] /><r:index [array="widgets"] /><r:reset [array="widgets"] /><r:index [array="widgets"] /></code></pre>
+  }
+  tag 'reset' do |tag|
+    key = tag.attr['array'] ||= 'array'
+    tag.globals.indexes[key] = 0
+    nil
   end
 
   desc %{

--- a/spec/models/standard_tags_spec.rb
+++ b/spec/models/standard_tags_spec.rb
@@ -966,47 +966,76 @@ describe "Standard Tags" do
   end
 
   describe '<r:index>' do
-    context 'invalid call' do
-      before :each do
-        @tag = %{<r:index />}
-      end
-      it 'should raise an exception' do
-        pages(:home).should render(@tag).with_error("`index' tag must contain an `array' attribute.")
-      end
-    end
-    
     context 'single array' do
-      before :each do
-        @tag = %{<r:index array='items' />}
-      end
-      context 'one call' do
-        it 'should render 0' do
-          pages(:home).should render(@tag).as(%{0})
+      context 'no key passed' do
+        before :each do
+          @tag = %{<r:index />}
+        end
+        context 'one call' do
+          it 'should render 0' do
+            pages(:home).should render(@tag).as(%{0})
+          end
+        end
+        context 'multiple calls' do
+          it 'should render incrementing indexes' do
+            tag = ''
+            4.times { tag << @tag }
+            pages(:home).should render(tag).as(%{0123})
+          end
         end
       end
-      context 'multiple calls' do
-        it 'should render incrementing indexes' do
-          tag = ''
-          4.times { tag << @tag }
-          pages(:home).should render(tag).as(%{0123})
+      context 'key passed' do
+        before :each do
+          @tag = %{<r:index array='items' />}
+        end
+        context 'one call' do
+          it 'should render 0' do
+            pages(:home).should render(@tag).as(%{0})
+          end
+        end
+        context 'multiple calls' do
+          it 'should render incrementing indexes' do
+            tag = ''
+            4.times { tag << @tag }
+            pages(:home).should render(tag).as(%{0123})
+          end
         end
       end
     end
     
     context 'multiple arrays' do
-      before :each do
-        @tag = %{<r:index array='items' /><r:index array='widgets' />}
-      end
-      context 'one call' do
-        it 'should render 0 for each' do
-          pages(:home).should render(@tag).as(%{00})
+      context 'no key passed' do
+        before :each do
+          @tag = %{<r:index /><r:index array='widgets' />}
+        end
+        context 'one call' do
+          it 'should render 0 for each' do
+            pages(:home).should render(@tag).as(%{00})
+          end          
+        end
+        context 'multiple calls' do
+          it 'should render indexes simultaneously' do
+            tag = ''
+            4.times { tag << @tag }
+            pages(:home).should render(tag).as(%{00112233})
+          end
         end
       end
-      context 'multiple calls' do
-        it 'should render indexes simultaneously' do
-          tag = ''
-          4.times { tag << @tag }
-          pages(:home).should render(tag).as(%{00112233})
+      context 'keys passed' do
+        before :each do
+          @tag = %{<r:index array='items' /><r:index array='widgets' />}
+        end
+        context 'one call' do
+          it 'should render 0 for each' do
+            pages(:home).should render(@tag).as(%{00})
+          end
+        end
+        context 'multiple calls' do
+          it 'should render indexes simultaneously' do
+            tag = ''
+            4.times { tag << @tag }
+            pages(:home).should render(tag).as(%{00112233})
+          end
         end
       end
     end
@@ -1020,6 +1049,81 @@ describe "Standard Tags" do
           tag = ''
           4.times { tag << @tag }
           pages(:home).should render(tag).as(%{001213425637})
+        end
+      end
+    end
+  end
+  
+  describe '<r:reset />' do
+    context 'single array' do
+      context 'no key passed' do
+        before :each do
+          @tag = %{<r:index /><r:reset /><r:index />}
+        end
+        context 'one call' do
+          it 'should render 00' do
+            pages(:home).should render(@tag).as(%{00})
+          end
+        end
+        context 'multiple calls' do
+          it 'should render incrementing indexes' do
+            tag = ''
+            4.times { tag << @tag }
+            pages(:home).should render(tag).as(%{00101010})
+          end
+        end
+      end
+      context 'key passed' do
+        before :each do
+          @tag = %{<r:index array='items' /><r:reset array='items' /><r:index array='items' />}
+        end
+        context 'one call' do
+          it 'should render 0' do
+            pages(:home).should render(@tag).as(%{00})
+          end
+        end
+        context 'multiple calls' do
+          it 'should render incrementing indexes' do
+            tag = ''
+            4.times { tag << @tag }
+            pages(:home).should render(tag).as(%{00101010})
+          end
+        end
+      end
+    end
+    context 'multiple arrays' do
+      context 'no key passed' do
+        before :each do
+          @tag = %{<r:index /><r:index array='widgets' /><r:reset /><r:index /><r:index array='widgets' />}
+        end
+        context 'one call' do
+          it 'should render 0 for each' do
+            pages(:home).should render(@tag).as(%{0001})
+          end          
+        end
+        context 'multiple calls' do
+          it 'should render indexes simultaneously' do
+            tag = ''
+            4.times { tag << @tag }
+            pages(:home).should render(tag).as(%{0001120314051607})
+          end
+        end
+      end
+      context 'keys passed' do
+        before :each do
+          @tag = %{<r:index array='items' /><r:index array='widgets' /><r:reset array='items' /><r:index array='items' /><r:index array='widgets' />}
+        end
+        context 'one call' do
+          it 'should render 0 for each' do
+            pages(:home).should render(@tag).as(%{0001})
+          end          
+        end
+        context 'multiple calls' do
+          it 'should render indexes simultaneously' do
+            tag = ''
+            4.times { tag << @tag }
+            pages(:home).should render(tag).as(%{0001120314051607})
+          end
         end
       end
     end


### PR DESCRIPTION
A set of tags to keep track of the index on a global, optionally named array object.

This can be used for outputting lists of items you need to number and for creating dynamic forms based on groups of objects.

The inspiration came from my work on shops, where I would like to output a form post ordering a group of line items. This allows me to generate a text field array such as 

```
...
<r:items:each:item>
  <li class="class">
    <input  name="classes[<r:index />][name]     value="<r:name />" />
    <select name="classes[<r:index />][location] value="<r:location />">...</select>
  </li>
</r:items:each:item>
...
```

resulting in

```
...
<li class="class">
  <input  name="classes[0][name]"     value="training 101" />
  <select name="classes[0][location]" value="Perth">...</select>
</li>
<li class="class">
  <input  name="classes[1][name]"     value="training 201" />
  <select name="classes[1][location]" value="Melbourne">...</select>
</li>
...
```

in some ways it duplicates functionality already available in `<r:cycle values="0,1,2,3,4,5,6,7" />` however this avoids you getting to overrun errors (as I did) when the parent array exceeds your available options

**specs have been written** :D/
