### PR TITLE
Added defaults.snippet.filter to the config view (and related files)

### DIFF
--- a/app/models/radiant/config.rb
+++ b/app/models/radiant/config.rb
@@ -50,6 +50,7 @@ module Radiant
     # defaults.page.status      :: a string representation of the default page status
     # defaults.page.filter      :: the default filter to use on new page parts
     # defaults.page.fields      :: a comma separated list of the default page fields
+    # defaults.snippet.filter   :: the default filter to use on new snippets
     # dev.host                  :: the hostname where draft pages are viewable
     # local.timezone            :: the timezone name (`rake -D time` for full list)
     #                              used to correct displayed times

--- a/app/views/admin/configuration/edit.html.haml
+++ b/app/views/admin/configuration/edit.html.haml
@@ -32,6 +32,8 @@
               = edit_config('defaults.page.parts')
             %p
               = edit_config('defaults.page.status')
+            %p
+              = edit_config('defaults.snippet.filter')
   
         - form.edit_users do
           %fieldset

--- a/app/views/admin/configuration/show.html.haml
+++ b/app/views/admin/configuration/show.html.haml
@@ -62,6 +62,8 @@
         = show_config 'defaults.page.fields'
       %p.ruled
         = show_config 'defaults.page.status'
+      %p.ruled
+        = show_config 'defaults.snippet.filter'
 
     - config.users do
       %h4 Passwords

--- a/config/initializers/radiant_config.rb
+++ b/config/initializers/radiant_config.rb
@@ -7,6 +7,7 @@ Radiant.config do |config|
   config.define 'defaults.page.status', :select_from => lambda { Status.selectable_values }, :allow_blank => true, :default => "Draft"
   config.define 'defaults.page.filter', :select_from => lambda { TextFilter.descendants.map { |s| s.filter_name }.sort }, :allow_blank => true
   config.define 'defaults.page.fields'
+  config.define 'defaults.snippet.filter', :select_from => lambda { TextFilter.descendants.map { |s| s.filter_name }.sort }, :allow_blank => true
   config.define 'pagination.param_name', :default => 'page'
   config.define 'pagination.per_page_param_name', :default => 'per_page'
   config.define 'admin.pagination.per_page', :type => :integer, :default => 50

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,6 +51,8 @@ en:
         filter: "page filter"
         parts: "page parts"
         status: "page status"
+      snippet:
+        filter: "snippet filter"
     dev:
       host: "dev site domain name"
     local:

--- a/spec/datasets/config_dataset.rb
+++ b/spec/datasets/config_dataset.rb
@@ -7,6 +7,7 @@ class ConfigDataset < Dataset::Base
     Radiant::Config['defaults.page.status'] = 'draft'
     Radiant::Config['defaults.page.filter'] = nil
     Radiant::Config['defaults.page.fields'] = 'keywords, description'
+    Radiant::Config['defaults.snippet.filter'] = nil
     Radiant::Config['session_timeout'] = 2.weeks
   end
 end

--- a/spec/fixtures/invalid_config.yml
+++ b/spec/fixtures/invalid_config.yml
@@ -7,4 +7,5 @@
  admin.subtitle: Publishing for Small Teams
  this: that
  defaults.page.filter: ""
+ defaults.snippet.filter: ""
  true?: true


### PR DESCRIPTION
As a follow up to my recent commit ([d0130a161ece910d0e24](https://github.com/radiant/radiant/commit/d0130a161ece910d0e245dc2b606d14bc2090d64)) I added defaults.snippet.filter to the config page (/admin/config).

Can anyone else double check my work? It all appears to be working fine for me, but I like to have a second eye look at things.

I'll be happy to merge the pull request once someone else has looked over this.
