### PR TITLE
Extension loader fixed to load gems packed by bundler from git and gems with letters in version

### DIFF
--- a/lib/radiant/extension_loader.rb
+++ b/lib/radiant/extension_loader.rb
@@ -81,7 +81,7 @@ module Radiant
       @observer ||= DependenciesObserver.new(configuration).observe(::ActiveSupport::Dependencies)
       self.extensions = load_extension_roots.map do |root|
         begin
-          extension_file = "#{File.basename(root).gsub(/^radiant-|-extension-[\d.]+$/,'')}_extension"
+          extension_file = "#{File.basename(root).gsub(/^radiant-|-extension-([\d\.a-z]+|[a-z\d]+)$/,'')}_extension"
           extension = extension_file.camelize.constantize
           extension.unloadable
           extension.root = root
@@ -141,7 +141,7 @@ module Radiant
             :all
           else
             ext_path = all_roots.detect do |maybe_path|
-              File.basename(maybe_path).gsub(/^radiant-|-extension-[\d.]+$/, '') == ext_name.to_s
+              File.basename(maybe_path).gsub(/^radiant-|-extension-([\d\.a-z]+|[a-z\d]+)$/, '') == ext_name.to_s
             end
             raise LoadError, "Cannot find the extension '#{ext_name}'!" if ext_path.nil?
             all_roots.delete(ext_path)
@@ -161,7 +161,7 @@ module Radiant
           end
           configuration.gems.inject(roots) do |paths,gem|
             paths.tap { |p| p << gem.specification.full_gem_path if gem.specification and
-                            gem.specification.full_gem_path[/radiant-.*-extension-[\d\.]+$/] }
+                            gem.specification.full_gem_path[/radiant-.*-extension-([\d\.a-z]+|[a-z\d]+)$/] }
           end
           roots.flatten
         end

--- a/spec/lib/radiant/extension_loader_spec.rb
+++ b/spec/lib/radiant/extension_loader_spec.rb
@@ -28,7 +28,7 @@ describe Radiant::ExtensionLoader do
     @initializer.should_receive(:configuration).and_return(@configuration)
     @instance.configuration.should == @configuration
   end
-
+  
   it "should only load extensions specified in the configuration" do
     @configuration.should_receive(:extensions).at_least(:once).and_return([:basic])
     @instance.stub!(:all_extension_roots).and_return(@extension_paths)
@@ -36,7 +36,14 @@ describe Radiant::ExtensionLoader do
   end
 
   it "should load gem extensions with paths matching radiant-*-extension" do
-    gem_path = File.join RADIANT_ROOT, %w(test fixtures gems radiant-gem_ext-extension-0.0.0)
+    gem_path = File.join RADIANT_ROOT, %w(test fixtures gems radiant-gem_ext-extension-61e0ad14a3ae)
+    @configuration.should_receive(:extensions).at_least(:once).and_return([:gem_ext])
+    @instance.stub!(:all_extension_roots).and_return([File.expand_path(gem_path)])
+    @instance.send(:select_extension_roots).should == [gem_path]
+  end
+
+  it "should load gem extensions packed by bundler from git" do
+    gem_path = File.join RADIANT_ROOT, %w(test fixtures gems radiant-gem_ext-extension-61e0ad14a3ae)
     @configuration.should_receive(:extensions).at_least(:once).and_return([:gem_ext])
     @instance.stub!(:all_extension_roots).and_return([File.expand_path(gem_path)])
     @instance.send(:select_extension_roots).should == [gem_path]


### PR DESCRIPTION
Now it could load gems fetched and packed from git by bundler (like radiant-gem_ext-sdh6d7j1gk8) and gems which have a-z characters in name (like compass-0.11.beta.2).
