### PR TITLE
Prevent Radiant::AvailableLocales.locales from loading dot files

### DIFF
--- a/lib/radiant/available_locales.rb
+++ b/lib/radiant/available_locales.rb
@@ -1,5 +1,5 @@
 module Radiant::AvailableLocales
-  
+
   def self.locale_paths
     root_locales = [File.join(RADIANT_ROOT, 'config', 'locales'), File.join(RAILS_ROOT, 'config', 'locales')].uniq
     unless root_locales.empty?
@@ -8,18 +8,18 @@ module Radiant::AvailableLocales
       Radiant::ExtensionLoader.locale_paths
     end
   end
-    
+
   def self.locales
     available_locales = {}
-    
-    locale_paths.each do |path|    
+
+    locale_paths.each do |path|
       if File.exists? path
-        Dir.new(path).entries.collect do |x|
-          result = x =~ /\.yml/ ? x.sub(/\.yml/,"") : nil
+        Dir.glob(path + "/*.yml").collect do |x|
+          result = File.basename(x, ".yml")
           # filters out the available_tags files
           result =~ /\_available_tags/ ? nil : result
         end.compact.each do |str|
-          locale_file = YAML.load_file(path + "/" + str + ".yml")
+          locale_file = YAML.load_file(File.join(path, str) + ".yml")
           lang = locale_file[str]["this_file_language"] if locale_file[str]
           available_locales.merge! Hash[lang, str] if lang
         end.freeze


### PR DESCRIPTION
While working on some locale yml files I noticed that macvim creates swap files named along the lines of .en.swp.yml which Radiant::AvailableLocales.locales will try to parse and crash on. More of an annoyance while trying to work/test but changing it to use Dir.glob() which doesn't load dot files fixes the issue.
