### PR TITLE
HAML Dependency

### DIFF
--- a/config/environment.rb
+++ b/config/environment.rb
@@ -89,4 +89,5 @@ Radiant::Initializer.run do |config|
   
   config.gem 'compass', :version => '~> 0.10.6'
   config.gem 'will_paginate', :version => '~> 2.3.11'
+  config.gem 'haml', :version => '3.0.25'
 end


### PR DESCRIPTION
If I recall correctly, HAML used to be vendored but now isn't.  This adds the dependency to environment.rb and specifies 3.0.25 exactly.  I started digging when my installed 3.0.16 caused a crash below.  3.0.25 works fine.

```
Rendering admin/welcome/login

ActionView::TemplateError (undefined method `inspect_obj' for #<Haml::Engine:0x10393ec08>) in vendor/radiant/app/views/admin/welcome/login.html.haml:

    vendor/radiant/vendor/plugins/haml/rails/./lib/haml/precompiler.rb:323:in `flush_merged_text'
    vendor/radiant/vendor/plugins/haml/rails/./lib/haml/precompiler.rb:320:in `each'
    vendor/radiant/vendor/plugins/haml/rails/./lib/haml/precompiler.rb:320:in `flush_merged_text'
    vendor/radiant/vendor/plugins/haml/rails/./lib/haml/precompiler.rb:292:in `push_silent'
    vendor/radiant/vendor/plugins/haml/rails/./lib/haml/precompiler.rb:239:in `process_line'
    vendor/radiant/vendor/plugins/haml/rails/./lib/haml/precompiler.rb:178:in `precompile'
    vendor/radiant/vendor/plugins/haml/rails/./lib/haml/engine.rb:121:in `initialize'
    vendor/radiant/vendor/plugins/haml/rails/./lib/haml/template/plugin.rb:34:in `new'
    vendor/radiant/vendor/plugins/haml/rails/./lib/haml/template/plugin.rb:34:in `compile'
    vendor/radiant/vendor/plugins/haml/rails/./lib/haml/template/plugin.rb:39:in `call'
    vendor/radiant/vendor/plugins/haml/rails/./lib/haml/helpers/action_view_mods.rb:13:in `render'
    vendor/radiant/vendor/plugins/haml/rails/./lib/haml/helpers/action_view_mods.rb:13:in `render'
    compass (0.10.6) lib/compass/app_integration/rails/actionpack2/action_controller.rb:7:in `process'
    vendor/radiant/vendor/plugins/haml/rails/./lib/sass/plugin/rack.rb:41:in `call'
```
