### PR TITLE
Mods to get Radiant 0.9.1 working with RubyGems 1.7.2

### DIFF
--- a/config/environment.rb
+++ b/config/environment.rb
@@ -9,6 +9,20 @@ require File.join(File.dirname(__FILE__), 'boot')
 
 require 'radius'
 
+# Play nice with Rubygems 1.6+. This is only required for Radiant 0.9.1
+# because it uses an older Rails version. Newer versions of Radiant (master)
+# use a newer Rails
+if Gem::VERSION >= "1.3.6" 
+    module Rails
+        class GemDependency
+            def requirement
+                r = super
+                (r == Gem::Requirement.default) ? nil : r
+            end
+        end
+    end
+end
+
 Radiant::Initializer.run do |config|
   # Skip frameworks you're not going to use (only works if using vendor/rails).
   # To use Rails without a database, you must remove the Active Record framework

--- a/config/preinitializer.rb
+++ b/config/preinitializer.rb
@@ -1,0 +1,1 @@
+require 'thread'  # for RubyGems 1.7.2 support


### PR DESCRIPTION
Hello Radiant Devs,

Here is a patch for Radiant 0.9.1 to get it working with Rubygems 1.7.2. Rubygems 1.6 stopped requiring the thread library, but the version of Rails that Radiant 0.9.1 freezes depends on that functionality.

This patch pulls in the thread library and sets up everything how the frozen Rails expects it.

Note: This patch is only required for Radiant 0.9.1. I checked master and that version of Radiant works correctly without it. Which is great (I guess you updated your Rails version in master)

As a Radiant n00b I set up my Radiant site by downloading the latest stable version from RubyGems, and was dismayed when it didn't work with my version of Rubygems.

I believe this is the smallest possible change to get Radiant 0.9.1 up and working (maybe it would be worth a 0.9.2 release for this patch?)

Hope this helps,
_Ryan Wilcox
