### PR TITLE
Removed custom pluralize method in the application helper.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -41,18 +41,6 @@ module ApplicationHelper
     submit_tag t('buttons.save_and_continue'), :name => 'continue', :class => 'button', :accesskey => "s"
   end
   
-  # Redefine pluralize() so that it doesn't put the count at the beginning of
-  # the string.
-  def pluralize(count, singular, plural = nil)
-    if count == 1
-      singular
-    elsif plural
-      plural
-    else
-      ActiveSupport::Inflector.pluralize(singular)
-    end
-  end
-  
   def current_item?(item)
     if item.tab && item.tab.many? {|i| current_url?(i.relative_url) }
       # Accept only stricter URL matches if more than one matches


### PR DESCRIPTION
The pluralize method in app/helpers/application_helper.rb overrides the Rails ActionView::Helpers::TextHelper.pluralize method. The new functionality specifies that pluralize(5, "hand") should return "hands" instead of "5 hands".

I removed this custom pluralize method from the Radiant code. Overriding the default Rails functionality is both confusing and unnecessary. It is confusing because it is not readily apparent why the number gets left off when you view a page that uses the pluralize method. It took me awhile to troubleshoot this today. I'm not the only one who has had this problem; see http://www.ruby-forum.com/topic/166162. My tests were consistently showing the number in the return string. My development environment only showed the pluralized word without a number in front of it.

Overriding the Rails pluralize method is unnecessary because Rails already provides this functionality in the ActiveSupport::CoreExtensions::String::Inflections module. So "hand".pluralize already returns "hands". I'd like to request that you not override the Rails ActionView::Helpers::TextHelper.pluralize method.

Best regards,
Michael
