### PR TITLE
Added tighter dependency on Highline as their later release broke things

### DIFF
--- a/radiant.gemspec
+++ b/radiant.gemspec
@@ -30,7 +30,7 @@ a general purpose content managment system--not merely a blogging engine.}
   s.add_dependency "compass",       "~> 0.11.1"
   s.add_dependency "delocalize",    "~> 0.2.3"
   s.add_dependency "haml",          "~> 3.1.1"
-  s.add_dependency "highline",      "~> 1.6.2"
+  s.add_dependency "highline",      "1.6.2"
   s.add_dependency "rack",          "~> 1.1.1"
   s.add_dependency "rack-cache",    "~> 1.0.2"
   s.add_dependency "rake",          ">= 0.8.7"


### PR DESCRIPTION
rake db:bootstrap would fail using e.g. highline 1.6.5 with the error:

undefined method `parse' for String:Class
/Library/Ruby/Gems/1.8/gems/highline-1.6.5/lib/highline/question.rb:329:in`convert'
/Library/Ruby/Gems/1.8/gems/highline-1.6.5/lib/highline.rb:253:in `ask'
…/radiant/lib/radiant/setup.rb:92:in`prompt_for_admin_name'
…/radiant/lib/radiant/setup.rb:29:in `create_admin_user'
…/radiant/lib/radiant/setup.rb:19:in`bootstrap'
…/radiant/lib/radiant/setup.rb:10:in `bootstrap'
…/radiant/lib/tasks/database.rake:43
[…]
