### PR TITLE
Added in sqlite3-ruby as it's no longer in the dependencies. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ This will install the gem with the prerelease name, for example: ‘radiant-0.9.
 
 To run tests you will need to have the following gems installed:
 
-  gem install ZenTest rspec rspec-rails cucumber webrat nokogiri
+  gem install ZenTest rspec rspec-rails cucumber webrat nokogiri sqlite3-ruby
 
 ## Support
 


### PR DESCRIPTION
According to https://github.com/radiant/radiant/commit/b7f2778ed2273057b31570f60dc163f566bf9774 sqlite3's been removed from the dependencies. Without sqlite3 being installed, the initial rake bootstrap command fails due to sqlite3 in the Gemfile.

(Caveat: Hopefully this makes sense as it's 1:53am and I just had to work around this while installing on my server)
