### PR TITLE
making page/snippet/layout/etc icons clickable

### DIFF
--- a/app/views/admin/layouts/index.html.haml
+++ b/app/views/admin/layouts/index.html.haml
@@ -19,8 +19,7 @@
             - render_region :tbody, :locals => {:layout => layout} do |tbody|
               - tbody.title_cell do
                 %td.name
-                  = image('layout', :alt => '')
-                  = link_to layout.name, edit_admin_layout_url(layout)
+                  = link_to image('layout', :alt => '') + ' ' + layout.name, edit_admin_layout_url(layout)
               - tbody.actions_cell do
                 %td.actions
                   = link_to image('minus') + ' ' + t('remove'), remove_admin_layout_url(layout), :class => "action"

--- a/app/views/admin/pages/index.html.haml
+++ b/app/views/admin/pages/index.html.haml
@@ -23,4 +23,4 @@
 - unless @homepage
   #actions
     %ul
-      %li= link_to image('plus') + " " + t("new_homepage"), new_admin_page_path, :class => 'action_button'
+      %li= link_to image('plus') + ' ' + t("new_homepage"), new_admin_page_path, :class => 'action_button'

--- a/app/views/admin/snippets/index.html.haml
+++ b/app/views/admin/snippets/index.html.haml
@@ -17,8 +17,7 @@
             - render_region :tbody, :locals => {:snippet => snippet} do |tbody|
               - tbody.title_cell do
                 %td.name
-                  = image('snippet', :alt => '')
-                  = link_to snippet.name, edit_admin_snippet_url(snippet)
+                  = link_to image('snippet', :alt => '') + ' ' + snippet.name, edit_admin_snippet_url(snippet)
               - tbody.actions_cell do
                 %td.actions
                   = link_to image('minus') + ' ' + t('remove'), remove_admin_snippet_url(snippet), :class => "action"


### PR DESCRIPTION
would there be any problem with making the icons clickable? i often find myself trying to click them since they (appear to be) a bigger target.

i think ideally the entire row would be clickable and unless you're targeting a specific action (expand, remove, etc) that it would go to the edit page.

thoughts?
