### PR TITLE
making script/extension work when you're out of script folder (in ruby 1.9)

### DIFF
--- a/script/extension
+++ b/script/extension
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-require File.dirname(__FILE__) + "/../config/boot"
+require File.expand_path('../../config/boot',  __FILE__)
 require 'radiant/extension/script'
 
 Radiant::Extension::Script.execute ARGV


### PR DESCRIPTION
script/server already has this patch but not script/extension
