### PR TITLE
Extension generator typo

### DIFF
--- a/lib/generators/extension/templates/RSpecRakefile
+++ b/lib/generators/extension/templates/RSpecRakefile
@@ -97,7 +97,7 @@ namespace :spec do
 end
 
 desc 'Generate documentation for the <%= file_name %> extension.'
-RDoc:Task.new(:rdoc) do |rdoc|
+RDoc::Task.new(:rdoc) do |rdoc|
   rdoc.rdoc_dir = 'rdoc'
   rdoc.title    = '<%= class_name %>'
   rdoc.options << '--line-numbers' << '--inline-source'

--- a/lib/generators/extension/templates/Rakefile
+++ b/lib/generators/extension/templates/Rakefile
@@ -13,7 +13,7 @@ Rake::TestTask.new(:test) do |t|
 end
 
 desc 'Generate documentation for the <%= file_name %> extension.'
-RDoc:Task.new(:rdoc) do |rdoc|
+RDoc::Task.new(:rdoc) do |rdoc|
   rdoc.rdoc_dir = 'rdoc'
   rdoc.title    = '<%= class_name %>'
   rdoc.options << '--line-numbers' << '--inline-source'


### PR DESCRIPTION
Picked up this typo while trying to generate an extension and run tests.
