### PR TITLE
MenuRenderer#allowed_child_classes

### DIFF
--- a/app/models/menu_renderer.rb
+++ b/app/models/menu_renderer.rb
@@ -35,7 +35,7 @@ module MenuRenderer
   end
 
   def allowed_child_classes
-    (allowed_children_cache.to_s.split(',') - Array(excluded_class_names)).map(&:constantize)
+    (allowed_children_cache.to_s.split(',') - Array(excluded_class_names)).map{|name|name.constantize rescue nil}.compact
   end
 
   def default_child_item

--- a/spec/models/menu_renderer_spec.rb
+++ b/spec/models/menu_renderer_spec.rb
@@ -118,6 +118,12 @@ describe MenuRenderer do
         special_page.allowed_child_classes
       }.should_not raise_error
     end
+    it 'should not raise error when the allowed_children_cache is unable to find a class' do
+      special_page.allowed_children_cache = 'Page, SpecialChildPa' #the last class name is truncated by limit in database
+      lambda{
+        special_page.allowed_child_classes
+      }.should_not raise_error
+    end
   end
 
   describe '#default_child_item' do


### PR DESCRIPTION
Fix the ISSUE#316

MenuRenderer#allowed_child_classes throws error if allowed_children_cache is trimmed by db limit. This should ignore the missing classes and continue.
