### PR TITLE
Removed nested transaction which always commits page change on preview, Fixes GH-319

### DIFF
--- a/app/controllers/admin/pages_controller.rb
+++ b/app/controllers/admin/pages_controller.rb
@@ -1,7 +1,7 @@
 class Admin::PagesController < Admin::ResourceController
   before_filter :initialize_meta_rows_and_buttons, :only => [:new, :edit, :create, :update]
   before_filter :count_deleted_pages, :only => [:destroy]
-  skip_before_filter :verify_authenticity_token, :only => [:preview]
+  
   class PreviewStop < ActiveRecord::Rollback
     def message
       'Changes not saved!'


### PR DESCRIPTION
For some reason the nested transaction in Admin::PagesController#render_preview commits the transaction even though the PreviewStop error is raised. Removing the inner transaction fixes this.
