### PR TITLE
Minor update to the navigation rendering cuke test

### DIFF
--- a/features/navigation_rendering.feature
+++ b/features/navigation_rendering.feature
@@ -9,7 +9,7 @@ Feature: Rendering the navigation tag
     And I follow "Main"
     And I fill in the "layout_content" content with the text
     """
-    <r:navigation urls="First: /first | Another: /another | Parent: /parent">
+    <r:navigation paths="First: /first | Another: /another | Parent: /parent">
       <r:normal><a href="<r:path />"><r:title /></a></r:normal>
       <r:here><strong><r:title /></strong></r:here>
       <r:selected><strong><a href="<r:path />"><r:title /></a></strong></r:selected>


### PR DESCRIPTION
Gets rid of the annoying deprecation warning when running the tests.

I couldn't see any reason not to change it, but I didn't know if the same tests needed to be run on an old branch and needed backwards compatibility, or when the Rails 3 stuff was going to be merged in, so I'll wait for feedback before merging.
