### PR TITLE
Force form params into UTF-8 encoding when using Ruby 1.9.x

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,6 +11,7 @@ class ApplicationController < ActionController::Base
   before_filter :set_timezone
   before_filter :set_user_locale
   before_filter :set_javascripts_and_stylesheets
+  before_filter :force_utf8_params if RUBY_VERSION =~ /1\.9/
   before_filter :set_standard_body_style, :only => [:new, :edit, :update, :create]
   
   attr_accessor :config, :cache
@@ -82,6 +83,31 @@ class ApplicationController < ActionController::Base
     def set_standard_body_style
       @body_classes ||= []
       @body_classes.concat(%w(reversed))
+    end
+    
+    # When using Radiant with Ruby 1.9, the strings that come in from forms are ASCII-8BIT encoded.
+    # That causes problems, especially when using special chars and with certain DBs, like DB2
+    # That's why we force the encoding of the params to UTF-8
+    # That's what's happening in Rails 3, too: https://github.com/rails/rails/commit/25215d7285db10e2c04d903f251b791342e4dd6a
+    #
+    # See http://stackoverflow.com/questions/8268778/rails-2-3-9-encoding-of-query-parameters
+    # See https://rails.lighthouseapp.com/projects/8994/tickets/4807
+    # See http://jasoncodes.com/posts/ruby19-rails2-encodings (thanks for the following code, Jason!)
+    def force_utf8_params      
+      traverse = lambda do |object, block|
+        if object.kind_of?(Hash)
+          object.each_value { |o| traverse.call(o, block) }
+        elsif object.kind_of?(Array)
+          object.each { |o| traverse.call(o, block) }
+        else
+          block.call(object)
+        end
+        object
+      end
+      force_encoding = lambda do |o|
+        o.force_encoding(Encoding::UTF_8) if o.respond_to?(:force_encoding)
+      end
+      traverse.call(params, force_encoding)
     end
     
 end

--- a/spec/controllers/admin/pages_controller_spec.rb
+++ b/spec/controllers/admin/pages_controller_spec.rb
@@ -1,3 +1,5 @@
+#encoding: utf-8
+
 require File.dirname(__FILE__) + '/../../spec_helper'
 
 describe Admin::PagesController do
@@ -290,6 +292,19 @@ describe Admin::PagesController do
       put :update, :id => page_id(:home), :page => {:breadcrumb => 'Homepage'} and sleep(1)
       final_updated_at = pages(:home).updated_at
       lambda{ next_updated_at <=> final_updated_at }.should be_true
+    end
+    
+    it 'should convert form input to UTF-8' do
+      # When using Radiant with Ruby 1.9, the strings that come in from forms are ASCII-8BIT encoded.
+      # That causes problems, especially when using special chars and with certain DBs, like DB2
+      #
+      # See http://stackoverflow.com/questions/8268778/rails-2-3-9-encoding-of-query-parameters
+      # See https://rails.lighthouseapp.com/projects/8994/tickets/4807
+      # See http://jasoncodes.com/posts/ruby19-rails2-encodings
+      
+      put :update, :id => page_id(:home), :page => {:breadcrumb => 'Homepage', :parts_attributes => {'0' => {:id => pages(:home).parts[0].id, :content => 'Ümlautö'.force_encoding('ASCII-8BIT')}}} and sleep(1)
+      params['page']['parts_attributes']['0']['content'].encoding.to_s.should == 'UTF-8'
+      params['page']['parts_attributes']['0']['content'].should == 'Ümlautö'
     end
   end
   


### PR DESCRIPTION
This is basically a back port of Rails 3 built-in behavior.

Background: When entering special chars like umlauts in Radiant forms (like the admin page forms), these strings enter Rails as ASCII-8BIT-encoded strings. That causes lots of problems, especially with some DB-backends like DB2.

The solution is to force the encoding of incoming params to UTF-8. While that is not a perfect solution, it's much better than the current situation.

More background: 

Rails discussion about this: https://rails.lighthouseapp.com/projects/8994/tickets/4807 
@wycats' commit to Rails 3: https://github.com/rails/rails/commit/25215d7285db10e2c04d903f251b791342e4dd6a
SO discussion: http://stackoverflow.com/questions/8268778/rails-2-3-9-encoding-of-query-parameters
Blog post: http://jasoncodes.com/posts/ruby19-rails2-encodings (thanks for the following code, Jason!)

Let me know what you guys think.
- Johannes
