### PR TITLE
Duplicate snippets patch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,6 @@ gem "sqlite3", "1.3.4", :group => [:development, :test], :platform => :ruby
 # gem "radiant-snippets-extension",            "~> 1.0.1"
 # gem "radiant-site_templates-extension",      "~> 1.0.4"
 # gem "radiant-smarty_pants_filter-extension", "~> 1.0.2"
-# gem "radiant-snippets-extension",            "~> 1.0.0"
 # gem "radiant-textile_filter-extension",      "~> 1.0.4"
 
 if ENV['TRAVIS']


### PR DESCRIPTION
Removed a duplicate entry in the Gemfile (snippets was listed twice in the commented out debug dependencies). Not a big deal, just a minor annoyance if you go to debug and don't notice it at first.

I wasn't sure which version to leave, so I left the more recent one.
