### PR TITLE
Clean up bundler requires.

### DIFF
--- a/config/preinitializer.rb
+++ b/config/preinitializer.rb
@@ -1,19 +1,18 @@
-begin
-  require "rubygems"
-  require "bundler"
-rescue LoadError
-  raise "Could not load the bundler gem. Install it with `gem install bundler`."
-end
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
+# Lessens Debians need to edit.
+require "rubygems" rescue nil
 
-if Gem::Version.new(Bundler::VERSION) <= Gem::Version.new("1.0.0")
-  raise RuntimeError, "Your bundler version is too old for Rails 2.3. " +
-   "Run `gem install bundler` to upgrade."
-end
+# Since Bundler is not really a 'must have' for Rails development just send off
+# a warning and see if the sytem continues to load, the user can optionally use
+# RADIANT_NOWARNINGS to disable it.
 
-begin
-  # Set up load paths for all bundled gems
-  ENV["BUNDLE_GEMFILE"] = File.expand_path("../../Gemfile", __FILE__)
-  Bundler.setup
-rescue Bundler::GemNotFound => e
-  raise RuntimeError, "Bundler couldn't find some gems: #{e}. Did you run `bundle install`?"
+if File.file?(ENV['BUNDLE_GEMFILE'])
+  begin
+    require 'bundler/setup'
+  rescue LoadError
+    unless ENV['RADIANT_NOWARNINGS'] == true
+      $stderr.puts 'WARNING: It seems you do not have Bundler installed.'
+      $stderr.puts 'WARNING: You can install it by doing `gem install bundler`'
+    end
+  end
 end


### PR DESCRIPTION
I think this is the best approach, it doesn't explicitly require Bundler and all the other checks should really be done in the gemspec IMO.  The main problem I had that prompted me to make this pull request is the fact that you guys completely assume that I use Gemfile and kill my predefined BUNDLE_GEMFILE so now I am either stuck with the badly named Gemfile instead of gemfile.rb that I would prefer for my projects.  At the least I think it should not overwrite BUNDLE_GEMFILE.
