### PR TITLE
Added missing `relative_url_root` in Ajax Updater

### DIFF
--- a/public/javascripts/admin/pagefield.js
+++ b/public/javascripts/admin/pagefield.js
@@ -2,7 +2,7 @@ function addField(form) {
   if (validFieldName()) {
     new Ajax.Updater(
       $('attributes').down('tbody'),
-      '/admin/page_fields/',
+      relative_url_root + '/admin/page_fields/',
       {
         asynchronous: true,
         evalScripts: true,


### PR DESCRIPTION
Prepended `relative_url_root` to the URL of an Ajax call so that this call works in Radiant apps which are deployed in sub directories
