### PR TITLE
fix mysql migration issue

### DIFF
--- a/db/migrate/20110902203823_add_allowed_children_cache_to_pages.rb
+++ b/db/migrate/20110902203823_add_allowed_children_cache_to_pages.rb
@@ -1,6 +1,6 @@
 class AddAllowedChildrenCacheToPages < ActiveRecord::Migration
   def self.up
-    add_column :pages, :allowed_children_cache, :text, :default => ''
+    add_column :pages, :allowed_children_cache, :text
     Page.reset_column_information
     Page.find_each do |page|
       page.save # update the allowed_children_cache


### PR DESCRIPTION
It fix the Mysql error : 

```
Mysql::Error: BLOB/TEXT column 'allowed_children_cache' can't have a default value
```
