### PR TITLE
Password Confirmation example in user spec

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -104,7 +104,7 @@ describe User, "validations" do
     end
 
     it 'ensures the confirmation matches' do
-      user.password = 'test1'
+      user.password = 'test'
       user.password_confirmation = 'not correct'
       expect(user.errors_on(:password_confirmation)).to include("doesn't match Password")
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -104,9 +104,9 @@ describe User, "validations" do
     end
 
     it 'ensures the confirmation matches' do
-      user.password = 'test'
+      user.password = 'test1'
       user.password_confirmation = 'not correct'
-      expect(user.errors_on(:password)).to include('this must match confirmation')
+      expect(user.errors_on(:password_confirmation)).to include("doesn't match Password")
     end
   end
 

--- a/spec/support/render_test_helper.rb
+++ b/spec/support/render_test_helper.rb
@@ -3,7 +3,7 @@ module RenderTestHelper
   def assert_renders(expected, input, url = nil, host = nil)
     output = get_render_output(input, url, host)
     message = "<#{expected.inspect}> expected but was <#{output.inspect}>"
-    assert_block(message) { expected == output }
+    expect(expected).to eq(output), message
   end
   
   def assert_render_match(regexp, input, url = nil)


### PR DESCRIPTION
Fixed failing example in user spec for password confirmation. Error message is changed and it is added to the password confirmation attribute.