### PR TITLE
fixed validate for config definitions

### DIFF
--- a/app/models/radiant/config.rb
+++ b/app/models/radiant/config.rb
@@ -318,7 +318,8 @@ Config definition error: '#{key}' is defined twice:
 
     delegate :default, :type, :allow_blank?, :hidden?, :visible?, :settable?, :selection, :notes, :units, to: :definition
 
-    def validate
+    validate :definition_must_be_valid
+    def definition_must_be_valid
       definition.validate(self)
     end
 

--- a/spec/lib/radiant/config/definition_spec.rb
+++ b/spec/lib/radiant/config/definition_spec.rb
@@ -49,7 +49,7 @@ describe "Radiant::Config::Definition" do
     })
   end
   after :each do
-    Radiant::Cache.clear
+    Radiant::Cache.clear if defined? Radiant::Cache
     Radiant.detail.clear_definitions!
   end
 
@@ -76,9 +76,9 @@ describe "Radiant::Config::Definition" do
 
     it "should validate against the supplied block" do
       setting = Radiant::Config.find_by_key('valid')
-      expect{setting.value = "Ape"}.to raise_error
+      expect{setting.value = "Ape"}.to raise_error(ActiveRecord::RecordInvalid)
       expect(setting.valid?).to be false
-      expect(setting.errors.on(:value)).to eq("That's no monkey")
+      expect(setting.errors[:value]).to include("That's no monkey")
     end
 
     it "should allow a valid value to be set" do
@@ -92,11 +92,11 @@ describe "Radiant::Config::Definition" do
     end
 
     it "should not allow an invalid value to be set" do
-      expect{Radiant::Config['valid'] = "Cow"}.to raise_error
+      expect{Radiant::Config['valid'] = "Cow"}.to raise_error(ActiveRecord::RecordInvalid)
       expect(Radiant::Config['valid']).not_to eq("Cow")
-      expect{Radiant::Config['selecting'] = "Pig"}.to raise_error
-      expect{Radiant::Config['number'] = "Pig"}.to raise_error
-      expect{Radiant::Config['required'] = ""}.to raise_error
+      expect{Radiant::Config['selecting'] = "Pig"}.to raise_error(ActiveRecord::RecordInvalid)
+      expect{Radiant::Config['number'] = "Pig"}.to raise_error(ActiveRecord::RecordInvalid)
+      expect{Radiant::Config['required'] = ""}.to raise_error(ActiveRecord::RecordInvalid)
     end
   end
 
@@ -149,7 +149,7 @@ describe "Radiant::Config::Definition" do
     end
 
     it "should raise a validation error when a required value is made blank" do
-      expect{ Radiant::Config['required'] = "" }.to raise_error
+      expect{ Radiant::Config['required'] = "" }.to raise_error(ActiveRecord::RecordInvalid)
     end
   end
 

--- a/spec/models/radiant/config_spec.rb
+++ b/spec/models/radiant/config_spec.rb
@@ -1,5 +1,5 @@
 require File.dirname(__FILE__) + "/../../spec_helper"
-
+require RADIANT_ROOT + "/lib/radiant/cache"
 describe Radiant::Config do
   before :each do
     Radiant.detail.initialize_cache

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,8 @@
 # Configure Rails Envinronment
 ENV["RAILS_ENV"] = "test"
 # # require File.expand_path("../internal/config/environment.rb",  __FILE__)
-# SPEC_ROOT = File.dirname(__FILE__)
-#
+SPEC_ROOT = File.dirname(__FILE__)
+
 
 require 'rubygems'
 require 'bundler/setup'


### PR DESCRIPTION
removed overriding of validate of active record base and called it the right way
raise error matcher to use specific error message