### PR TITLE
fix deprecation in release.rake / remove has_rdoc

### DIFF
--- a/lib/tasks/release.rake
+++ b/lib/tasks/release.rake
@@ -37,7 +37,6 @@ namespace 'radiant' do
     s.add_dependency 'compass', '~> 0.10.4'
     s.add_dependency 'will_paginate', '~> 2.3.11'
     s.add_dependency 'RedCloth', '>=4.2.0'
-    s.has_rdoc = true
     s.rdoc_options << '--title' << RDOC_TITLE << '--line-numbers' << '--main' << 'README'
     rdoc_excludes = Dir["**"].reject { |f| !File.directory? f }
     rdoc_excludes.each do |e|


### PR DESCRIPTION
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
Gem::Specification#has_rdoc= called from radiant-master/lib/tasks/release.rake:40.