### PR TITLE
fix deprecation: accessing mime types via constants

### DIFF
--- a/lib/login_system.rb
+++ b/lib/login_system.rb
@@ -70,7 +70,7 @@ module LoginSystem
     end
 
     def login_from_http
-      if [Mime::XML, Mime::JSON].include?(request.format)
+      if [Mime[:xml], Mime[:json].include?(request.format)
         authenticate_with_http_basic do |user_name, password|
           User.authenticate(user_name, password)
         end


### PR DESCRIPTION
Accessing mime types via constants is deprecated.  Please change:
  `Mime::XML`
to:
  `Mime::Type[:xml]`

Mime[:xml] works in Rails 2.3, 3.0, 6.0 ... should be fine.