### PR TITLE
fix ruby 2.6: warning: constant ::Fixnum is deprecated

### DIFF
--- a/lib/radiant/admin_ui.rb
+++ b/lib/radiant/admin_ui.rb
@@ -18,7 +18,7 @@ module Radiant
       end
 
       def [](id)
-        unless id.kind_of? Fixnum
+        unless id.kind_of? Integer
           self.find {|subnav_item| subnav_item.name.to_s.titleize == id.to_s.titleize }
         else
           super


### PR DESCRIPTION
0.kind_of?(Integer) works in Ruby 1.8.7, 1.9.3, 2.6.2