### PR TITLE
require at least ruby 1.9.3

### DIFF
--- a/radiant.gemspec
+++ b/radiant.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |s|
   s.name = %q{radiant}
   s.version = Radiant::Version.to_s
   s.platform = Gem::Platform::RUBY
-
+  s.required_ruby_version = '>= 1.9.3'
   s.required_rubygems_version = Gem::Requirement.new("> 1.3.1") if s.respond_to? :required_rubygems_version=
   s.authors = ["Radiant CMS dev team"]
   s.default_executable = %q{radiant}


### PR DESCRIPTION
"new" hash syntax makes it incompatible with ruby < 1.9