### PR TITLE
update .gemspec remove default_executable

### DIFF
--- a/radiant.gemspec
+++ b/radiant.gemspec
@@ -7,7 +7,6 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new("> 1.3.1") if s.respond_to? :required_rubygems_version=
   s.authors = ["Radiant CMS dev team"]
-  s.default_executable = %q{radiant}
   s.description = %q{Radiant is a simple and powerful publishing system designed for small teams.
 It is built with Rails and is similar to Textpattern or MovableType, but is
 a general purpose content managment system--not merely a blogging engine.}


### PR DESCRIPTION
> NOTE: Gem::Specification#default_executable= is deprecated with no replacement. It will be removed on or after 2018-12-01.