### PR TITLE
Gemspec: Drop EOL'd property rubyforge_project

### DIFF
--- a/radiant.gemspec
+++ b/radiant.gemspec
@@ -19,7 +19,6 @@ a general purpose content managment system--not merely a blogging engine.}
   s.homepage = %q{http://radiantcms.org}
   s.rdoc_options = ["--title", "Radiant -- Publishing for Small Teams", "--line-numbers", "--main", "README", "--exclude", "app", "--exclude", "bin", "--exclude", "config", "--exclude", "db", "--exclude", "features", "--exclude", "lib", "--exclude", "log", "--exclude", "pkg", "--exclude", "public", "--exclude", "script", "--exclude", "spec", "--exclude", "test", "--exclude", "tmp", "--exclude", "vendor"]
   s.require_paths = ["lib"]
-  s.rubyforge_project = %q{radiant}
   s.rubygems_version = %q{1.3.7}
   s.summary = %q{A no-fluff content management system designed for small teams.}
   s.license = %q{MIT}


### PR DESCRIPTION
The RubyGems property rubyforge_project is removed without a replacement.