### PR TITLE
chore: rewrite routing for Rails 8

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,47 @@
 Rails.application.routes.draw do
-  # Routes will be rewritten in issue #439.
-  # For now, define a minimal root so the app can boot.
-  root "site#show_page"
+
+  # Admin RESTful Routes
+  namespace :admin do
+    resources :pages do
+      member do
+        get :remove
+      end
+      resources :children, controller: "pages"
+    end
+    resources :layouts do
+      member do
+        get :remove
+      end
+    end
+    resources :users do
+      member do
+        get :remove
+      end
+    end
+
+    resource :preferences
+    resource :configuration, controller: "configuration"
+    resources :extensions, only: :index
+    resources :page_parts
+    resources :page_fields
+    get "reference/:type", to: "references#show", as: :reference
+  end
+
+  # Admin preview route
+  match "admin/preview", to: "admin/pages#preview", via: [:post, :put], as: :preview
+
+  # Admin welcome/login/logout routes
+  get "admin",         to: "admin/welcome#index",  as: :admin_welcome_index
+  get "admin/welcome", to: "admin/welcome#index",  as: :welcome
+  get "admin/login",   to: "admin/welcome#login",  as: :login
+  post "admin/login",  to: "admin/welcome#login"
+  get "admin/logout",  to: "admin/welcome#logout", as: :logout
+
+  # Site URLs
+  root to: "site#show_page"
+  get "error/404", to: "site#not_found", as: :not_found
+  get "error/500", to: "site#error",     as: :error
+
+  # Everything else — front-end catch-all (must be last)
+  get "*url", to: "site#show_page", as: :page
 end


### PR DESCRIPTION
## Summary

- Converted `config/routes.rb` from Rails 2.3 `map`-based DSL to modern Rails 8 routing
- Admin namespace with RESTful resources for pages, layouts, users (with `remove` member action)
- Nested children resources under pages
- Singular resources for preferences and configuration
- Preview route via `match` with POST/PUT
- Welcome/login/logout routes with named helpers
- Front-end catch-all `*url` route for SiteController
- All routes verified with `bin/rails routes`

## Test Plan

- [x] `bin/rails routes` outputs all expected routes without errors
- [ ] Admin routes functional after controllers updated (#440)
- [ ] Front-end catch-all works after models updated (#441)

Closes #439

🤖 Generated with [Claude Code](https://claude.com/claude-code)