### PR TITLE
chore: update controllers for Rails 8

### DIFF
--- a/app/controllers/admin/configuration_controller.rb
+++ b/app/controllers/admin/configuration_controller.rb
@@ -5,7 +5,7 @@ class Admin::ConfigurationController < ApplicationController
   # Note that configuration is routed as a singular resource so we only deal with show/edit/update
   # and the show and edit views determine what set of config values is shown and made editable.
   
-  before_filter :initialize_config
+  before_action :initialize_config
   
   only_allow_access_to :edit, :update,
     :when => [:admin],

--- a/app/controllers/admin/pages_controller.rb
+++ b/app/controllers/admin/pages_controller.rb
@@ -1,6 +1,6 @@
 class Admin::PagesController < Admin::ResourceController
-  before_filter :initialize_meta_rows_and_buttons, :only => [:new, :edit, :create, :update]
-  before_filter :count_deleted_pages, :only => [:destroy]
+  before_action :initialize_meta_rows_and_buttons, :only => [:new, :edit, :create, :update]
+  before_action :count_deleted_pages, :only => [:destroy]
   
   class PreviewStop < ActiveRecord::Rollback
     def message
@@ -32,7 +32,7 @@ class Admin::PagesController < Admin::ResourceController
   def preview
     render_preview
   rescue PreviewStop => exception
-    render :text => exception.message unless @performed_render
+    render :plain => exception.message unless performed?
   end
 
   private
@@ -58,7 +58,7 @@ class Admin::PagesController < Admin::ResourceController
         page_class = Page.descendants.include?(model_class) ? model_class : Page
         if request.referer =~ %r{/admin/pages/(\d+)/edit}
           page = Page.find($1).becomes(page_class)
-          page.update_attributes(params[:page])
+          page.update(params[:page])
           page.published_at ||= Time.now
         else
           page = page_class.new(params[:page])
@@ -72,7 +72,6 @@ class Admin::PagesController < Admin::ResourceController
     
     def process_with_exception(page)
       page.process(request, response)
-      @performed_render = true
       raise PreviewStop
     end
 

--- a/app/controllers/admin/preferences_controller.rb
+++ b/app/controllers/admin/preferences_controller.rb
@@ -1,5 +1,5 @@
 class Admin::PreferencesController < ApplicationController
-  before_filter :load_user
+  before_action :load_user
 
   def initialize
     @controller_name = 'user'
@@ -17,7 +17,7 @@ class Admin::PreferencesController < ApplicationController
 
   def update
     if valid_params?
-      if @user.update_attributes(params[:user])
+      if @user.update(params[:user])
         redirect_to admin_configuration_path
       else
         flash[:error] = t('preferences_controller.error_updating')

--- a/app/controllers/admin/resource_controller.rb
+++ b/app/controllers/admin/resource_controller.rb
@@ -3,11 +3,11 @@ class Admin::ResourceController < ApplicationController
   extend Radiant::ResourceResponses
   
   helper_method :model, :current_object, :models, :current_objects, :model_symbol, :plural_model_symbol, :model_class, :model_name, :plural_model_name
-  before_filter :populate_format
-  before_filter :never_cache
-  before_filter :load_models, :only => :index
-  before_filter :load_model, :only => [:new, :create, :edit, :update, :remove, :destroy]
-  after_filter :clear_model_cache, :only => [:create, :update, :destroy]
+  before_action :populate_format
+  before_action :never_cache
+  before_action :load_models, :only => :index
+  before_action :load_model, :only => [:new, :create, :edit, :update, :remove, :destroy]
+  after_action :clear_model_cache, :only => [:create, :update, :destroy]
 
   cattr_reader :paginated
   cattr_accessor :default_per_page, :will_paginate_options
@@ -58,7 +58,7 @@ class Admin::ResourceController < ApplicationController
   [:create, :update].each do |action|
     class_eval %{
       def #{action}                                       # def create
-        model.update_attributes!(params[model_symbol])    #   model.update_attributes!(params[model_symbol])
+        model.update!(params[model_symbol])               #   model.update!(params[model_symbol])
         response_for :#{action}                           #   response_for :create
       end                                                 # end
     }, __FILE__, __LINE__
@@ -115,21 +115,18 @@ class Admin::ResourceController < ApplicationController
     }
   end
 
+  rescue_from ActiveRecord::RecordInvalid do
+    response_for :invalid
+  end
+  rescue_from ActiveRecord::StaleObjectError do
+    response_for :stale
+  end
+  rescue_from ActiveRecord::RecordNotFound do
+    response_for :not_found
+  end
+
   protected
 
-    def rescue_action(exception)
-      case exception
-      when ActiveRecord::RecordInvalid
-        response_for :invalid
-      when ActiveRecord::StaleObjectError
-        response_for :stale
-      when ActiveRecord::RecordNotFound
-        response_for :not_found
-      else
-        super
-      end
-    end
-    
     def model_class
       self.class.model_class
     end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -5,7 +5,7 @@ class Admin::UsersController < Admin::ResourceController
     :denied_url => { :controller => 'pages', :action => 'index' },
     :denied_message => 'You must have administrative privileges to perform this action.'
 
-  before_filter :ensure_deletable, :only => [:remove, :destroy]
+  before_action :ensure_deletable, :only => [:remove, :destroy]
   
   def show
     redirect_to edit_admin_user_path(params[:id])
@@ -17,7 +17,7 @@ class Admin::UsersController < Admin::ResourceController
       user_params.delete('admin')
       annouce_cannot_remove_self_from_admin_role
     end
-    model.update_attributes!(user_params)
+    model.update!(user_params)
     response_for :update
   end
   

--- a/app/controllers/admin/welcome_controller.rb
+++ b/app/controllers/admin/welcome_controller.rb
@@ -1,7 +1,7 @@
 class Admin::WelcomeController < ApplicationController
   no_login_required
-  before_filter :never_cache
-  skip_before_filter :verify_authenticity_token
+  before_action :never_cache
+  skip_before_action :verify_authenticity_token
   
   def index
     redirect_to admin_pages_url

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,18 +1,13 @@
-require_dependency 'radiant'
-
 class ApplicationController < ActionController::Base
   include LoginSystem
-  
-  filter_parameter_logging :password, :password_confirmation
-  
-  protect_from_forgery
-  
-  before_filter :set_current_user
-  before_filter :set_timezone
-  before_filter :set_user_locale
-  before_filter :set_javascripts_and_stylesheets
-  before_filter :force_utf8_params if RUBY_VERSION =~ /1\.9/
-  before_filter :set_standard_body_style, :only => [:new, :edit, :update, :create]
+
+  protect_from_forgery with: :exception
+
+  before_action :set_current_user
+  before_action :set_timezone
+  before_action :set_user_locale
+  before_action :set_javascripts_and_stylesheets
+  before_action :set_standard_body_style, :only => [:new, :edit, :update, :create]
   
   attr_accessor :config, :cache
   attr_reader :pagination_parameters
@@ -51,15 +46,6 @@ class ApplicationController < ActionController::Base
     end
   end
     
-  def rescue_action_in_public(exception)
-    case exception
-      when ActiveRecord::RecordNotFound, ActionController::UnknownController, ActionController::UnknownAction, ActionController::RoutingError
-        render :template => "site/not_found", :status => 404
-      else
-        super
-    end
-  end
-  
   private
   
     def set_current_user
@@ -84,30 +70,5 @@ class ApplicationController < ActionController::Base
       @body_classes ||= []
       @body_classes.concat(%w(reversed))
     end
-    
-    # When using Radiant with Ruby 1.9, the strings that come in from forms are ASCII-8BIT encoded.
-    # That causes problems, especially when using special chars and with certain DBs, like DB2
-    # That's why we force the encoding of the params to UTF-8
-    # That's what's happening in Rails 3, too: https://github.com/rails/rails/commit/25215d7285db10e2c04d903f251b791342e4dd6a
-    #
-    # See http://stackoverflow.com/questions/8268778/rails-2-3-9-encoding-of-query-parameters
-    # See https://rails.lighthouseapp.com/projects/8994/tickets/4807
-    # See http://jasoncodes.com/posts/ruby19-rails2-encodings (thanks for the following code, Jason!)
-    def force_utf8_params      
-      traverse = lambda do |object, block|
-        if object.kind_of?(Hash)
-          object.each_value { |o| traverse.call(o, block) }
-        elsif object.kind_of?(Array)
-          object.each { |o| traverse.call(o, block) }
-        else
-          block.call(object)
-        end
-        object
-      end
-      force_encoding = lambda do |o|
-        o.force_encoding(Encoding::UTF_8) if o.respond_to?(:force_encoding)
-      end
-      traverse.call(params, force_encoding)
-    end
-    
+
 end

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -1,7 +1,7 @@
 class SiteController < ApplicationController
   include Radiant::Pagination::Controller
 
-  skip_before_filter :verify_authenticity_token
+  skip_before_action :verify_authenticity_token
   no_login_required
 
   def self.cache_timeout=(val)
@@ -22,7 +22,6 @@ class SiteController < ApplicationController
       batch_page_status_refresh if (url == "/" || url == "")
       process_page(@page)
       set_cache_control
-      @performed_render ||= true
     else
       render :template => 'site/not_found', :status => 404
     end
@@ -33,22 +32,19 @@ class SiteController < ApplicationController
   def cacheable_request?
     (request.head? || request.get?) && live?
   end
-  hide_action :cacheable_request?
 
   def set_expiry(time, options={})
     expires_in time, options
   end
-  hide_action :set_expiry
 
   def set_etag(val)
     headers['ETag'] = val
   end
-  hide_action :set_expiry
 
   private
     def batch_page_status_refresh
       @changed_pages = []
-      @pages = Page.find(:all, :conditions => {:status_id => Status[:scheduled].id})
+      @pages = Page.where(:status_id => Status[:scheduled].id)
       @pages.each do |page|
         if page.published_at <= Time.now
            page.status_id = Status[:published].id

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,6 +9,7 @@ module Radiant
     config.load_defaults 8.0
 
     config.time_zone = "UTC"
+    config.filter_parameters += [:password, :password_confirmation]
 
     # Radiant-specific inflections
     config.after_initialize do

--- a/lib/login_system.rb
+++ b/lib/login_system.rb
@@ -2,7 +2,7 @@ module LoginSystem
   def self.included(base)
     base.extend ClassMethods
     base.class_eval do
-      prepend_before_filter :authenticate, :authorize
+      prepend_before_action :authenticate, :authorize
       helper_method :current_user
     end
   end
@@ -30,7 +30,7 @@ module LoginSystem
         session['user_id'] = current_user.id
         true
       else
-        session[:return_to] = request.request_uri
+        session[:return_to] = request.fullpath
         respond_to do |format|
           format.html { redirect_to login_url }
           format.any(:xml,:json) { request_http_basic_authentication }
@@ -84,17 +84,17 @@ module LoginSystem
 
   module ClassMethods
     def no_login_required
-      skip_before_filter :authenticate
-      skip_before_filter :authorize
+      skip_before_action :authenticate
+      skip_before_action :authorize
     end
 
     def login_required?
-      filter_chain.any? {|f| f.method == :authenticate || f.method == :authorize }
+      _process_action_callbacks.any? { |c| [:authenticate, :authorize].include?(c.filter) }
     end
 
     def login_required
       unless login_required?
-        prepend_before_filter :authenticate, :authorize
+        prepend_before_action :authenticate, :authorize
       end
     end
 

--- a/lib/radiant/pagination/controller.rb
+++ b/lib/radiant/pagination/controller.rb
@@ -23,7 +23,7 @@ module Radiant::Pagination::Controller
   def self.included(base)
     base.class_eval {
       helper_method :pagination_parameters
-      before_filter :configure_pagination
+      before_action :configure_pagination
     }
   end
 


### PR DESCRIPTION
## Summary

- Replaced all deprecated callback methods (`before_filter` → `before_action`, etc.) across all controllers and lib modules
- Replaced `update_attributes`/`update_attributes!` → `update`/`update!` in all controllers
- Modernized `ApplicationController`: removed `require_dependency`, `filter_parameter_logging` (moved to `config.filter_parameters`), `rescue_action_in_public`, `force_utf8_params`
- Updated `Admin::ResourceController` to use `rescue_from` instead of `rescue_action`
- Updated `SiteController`: removed `@performed_render`, `hide_action`, use `Page.where()` 
- Updated `LoginSystem`: modern callback API, `request.fullpath`, `_process_action_callbacks`
- Updated `Radiant::Pagination::Controller`: `before_action`

## Test Plan

- [x] `bin/rails runner "puts 'Boot OK'"` succeeds
- [ ] Admin login flow works after models/schema updated (#441, #442)
- [ ] Page CRUD operations work end-to-end (#443)

Closes #440

🤖 Generated with [Claude Code](https://claude.com/claude-code)